### PR TITLE
"update Minimum network platform version"

### DIFF
--- a/k8s/helm/notary/values.yaml
+++ b/k8s/helm/notary/values.yaml
@@ -59,7 +59,7 @@ networkServices:
   networkMapURL: nmap:10000
 
 # Minimum platform version
-mpv: 3
+mpv: 4
 
 # Database configuration
 dataSourceProperties:


### PR DESCRIPTION
It seems that recent additions to Corda's functionality have required a minimum network platform version greater than 4.
I think that it would be a good idea to update the mpv of this template to 4 accordingly.

https://docs.r3.com/en/platform/corda/4.8/enterprise/cordapps/versioning.html#platform-version-matrix

Thanks !