### PR TITLE
fix notary docker image

### DIFF
--- a/k8s/helm/notary/values.yaml
+++ b/k8s/helm/notary/values.yaml
@@ -7,8 +7,8 @@ bashDebug: false
 
 # Docker images to use by the Notary Helm chart
 dockerImage:
-  name: corda/enterprise-notary
-  tag: 4.5.9-zulu-openjdk8u242
+  name: corda/corda-enterprise-alpine-zulu-java1.8-4.8.6
+  tag: RELEASE
   pullPolicy: Always
 
 # Volume size for Notary bin/ directory


### PR DESCRIPTION
* Notary image is incorrect: old jar version and open source, not enterprise.

```
corda/enterprise-notary:4.5.9-zulu-openjdk8u242
  Version: 4.5.9
  Revision: 62455a197286a081933961d8ca0bd9824b34a392
  Platform Version: 7
  Vendor: Corda Open Source
```

* I see 4.8.6 its the latest

```
corda/corda-enterprise-alpine-zulu-java1.8-4.8.6:RELEASE
  Version: 4.8.6
  Revision: 6bb405e0b9d97a93e9b0eb4ffbbffc689cba4499
  Platform Version: 10
  Vendor: Corda Enterprise Edition
```