### PR TITLE
ENT-12064: fix bootstrap.cenm.connections

### DIFF
--- a/k8s/helm/bootstrap.cenm.connections
+++ b/k8s/helm/bootstrap.cenm.connections
@@ -31,7 +31,7 @@ done
 
 releasePrefix=${PrefixVar:-cenm}
 
-gatewayPublicIP=$(kubectl get svc "${releasePrefix}"-gateway -o jsonpath='{.status.loadBalancer.ingress[0].*}')
+gatewayPublicIP=$(kubectl get svc "${releasePrefix}"-gateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 gatewayPort=$(kubectl get svc "${releasePrefix}"-gateway -o=jsonpath="{.spec.ports[0].port}")
 idmanServiceName="${releasePrefix}"-idman-ip
 
@@ -41,8 +41,8 @@ printf "%s:%s\n" "${gatewayPublicIP}" "${gatewayPort}"
 idmanPort=$(kubectl get svc "${releasePrefix}"-idman-ip -o=jsonpath="{.spec.ports[0].port}")
 nmapPort=$(kubectl get svc "${releasePrefix}"-nmap -o=jsonpath="{.spec.ports[0].port}")
 
-idmanPublicIP=$(kubectl get svc "${idmanServiceName}" -o jsonpath='{.status.loadBalancer.ingress[0].*}')
-nmapPublicIP=$(kubectl get svc "${releasePrefix}"-nmap -o jsonpath='{.status.loadBalancer.ingress[0].*}')
+idmanPublicIP=$(kubectl get svc "${idmanServiceName}" -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+nmapPublicIP=$(kubectl get svc "${releasePrefix}"-nmap -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 
 printf "\nPlease use this snippet in your node.conf to register Corda nodes:\n"
 printf "\nnetworkServices {\n"


### PR DESCRIPTION
Kubernetes ≥ 1.29 introduced a second variable to the `.status.loadBalancer.ingress[0]` path, causing the wildcard to match more than just the `.ip`. This fixes it by just requesting the IP from that `jsonpath`