### PR TITLE
ENT-14418: Use correct tag in CENM Docker images

### DIFF
--- a/k8s/helm/auth/values.yaml
+++ b/k8s/helm/auth/values.yaml
@@ -8,7 +8,7 @@ bashDebug: false
 # Docker images to use by the Auth Service Helm chart
 authImage:
   repository: corda/enterprise-auth
-  tag: 1.7-zulu-openjdk17.0.15
+  tag: 1.7.1-zulu-openjdk17.0.16
   pullPolicy: Always
 
 # Configuration for database

--- a/k8s/helm/gateway/values.yaml
+++ b/k8s/helm/gateway/values.yaml
@@ -8,7 +8,7 @@ bashDebug: false
 # Docker images to use by the Gateway Service Helm chart
 gatewayImage:
   repository: corda/enterprise-gateway
-  tag: 1.7-zulu-openjdk17.0.15
+  tag: 1.7.1-zulu-openjdk17.0.16
   pullPolicy: Always
 
 # Volume size for etc/ directory

--- a/k8s/helm/idman/values.yaml
+++ b/k8s/helm/idman/values.yaml
@@ -8,13 +8,13 @@ bashDebug: false
 # Docker images to use by the Identity Manager Service Helm chart
 dockerImage:
   name: corda/enterprise-identitymanager
-  tag: 1.7-zulu-openjdk17.0.15
+  tag: 1.7.1-zulu-openjdk17.0.16
   pullPolicy: Always
 
 # Docker images to use by CENM CLI Helm chart
 dockerImageCli:
   name: corda/enterprise-cli
-  tag: 1.7-zulu-openjdk17.0.15
+  tag: 1.7.1-zulu-openjdk17.0.16
   pullPolicy: Always
 
 # Volume size for etc/ directory

--- a/k8s/helm/nmap/values.yaml
+++ b/k8s/helm/nmap/values.yaml
@@ -17,12 +17,12 @@ volumeSizeNmapH2: 10Gi
 # Docker images to use for the Network Map Service Helm chart
 dockerImage:
   repository: corda/enterprise-networkmap
-  tag: 1.7-zulu-openjdk17.0.15
+  tag: 1.7.1-zulu-openjdk17.0.16
   pullPolicy: Always
 
 dockerImageCli:
   repository: corda/enterprise-cli
-  tag: 1.7-zulu-openjdk17.0.15
+  tag: 1.7.1-zulu-openjdk17.0.16
   pullPolicy: Always
 
 # Required parameter

--- a/k8s/helm/pki/values.yaml
+++ b/k8s/helm/pki/values.yaml
@@ -14,7 +14,7 @@ volumeSizePkiEtc: 1Gi
 # Docker images to use by the PKI Helm chart
 pkiImage:
   repository: corda/enterprise-pkitool
-  tag: 1.7-zulu-openjdk17.0.15
+  tag: 1.7.1-zulu-openjdk17.0.16
   pullPolicy: Always
 
 pkiJar:

--- a/k8s/helm/signer/values.yaml
+++ b/k8s/helm/signer/values.yaml
@@ -8,12 +8,12 @@ bashDebug: false
 # Docker images to use by the Signing Service Helm chart
 signerImage:
   repository: corda/enterprise-signer
-  tag: 1.7-zulu-openjdk17.0.15
+  tag: 1.7.1-zulu-openjdk17.0.16
   pullPolicy: Always
 
 dockerImageCli:
   repository: corda/enterprise-cli
-  tag: 1.7-zulu-openjdk17.0.15
+  tag: 1.7.1-zulu-openjdk17.0.16
   pullPolicy: Always
 
 # Volume size for the etc/ directory

--- a/k8s/helm/zone/values.yaml
+++ b/k8s/helm/zone/values.yaml
@@ -7,7 +7,7 @@ bashDebug: false
 
 image:
   repository: corda/enterprise-zone
-  tag: 1.7-zulu-openjdk17.0.15
+  tag: 1.7.1-zulu-openjdk17.0.16
   pullPolicy: Always
 
 # Database configuration


### PR DESCRIPTION
Use correct tag in CENM Docker images (updated to 1.7.1).
Tested the deployment, all components started up correctly now.